### PR TITLE
clear the path before reading the new Ltype

### DIFF
--- a/src/libdxfrw.cpp
+++ b/src/libdxfrw.cpp
@@ -1938,6 +1938,7 @@ bool dxfRW::processLType() {
             if (reading) {
                 ltype.update();
                 iface->addLType(ltype);
+                ltype.path.clear();
             }
             sectionstr = reader->getString();
             DRW_DBG(sectionstr); DRW_DBG("\n");


### PR DESCRIPTION
The path persists the previous data across Ltype-s, and cause incorrect dxf file format